### PR TITLE
Editable driver list for reports

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -39,6 +39,7 @@ div {
 
 #notice {
   color: green;
+  text-align: center;
 }
 
 .field_with_errors {

--- a/app/views/drivers/_feed.html.erb
+++ b/app/views/drivers/_feed.html.erb
@@ -19,7 +19,31 @@
     <tbody id="<%=data_id%>">
       <% @drivers.each do |driver| %>
         <tr driver="<%= driver.id %>">
-          <td><%= link_to driver.full_name, driver %></td>
+          <% if data_id == 'report-feed' %>
+            <% if params[:q] %>
+              <%
+                search_hash = {}
+                params[:q].each do |param|
+                  search_hash[param] = params[:q][param]
+                end
+                params.each do |param|
+                  if param == 'miles' || param == :miles
+                    search_hash[:miles] = params[param]
+                  end
+                end
+              %>
+            <% end %>
+            <td>
+              <%= link_to driver.full_name,
+                driver_path(
+                  id: driver.id,
+                  report: @drivers.map(&:id),
+                  search: search_hash
+                ) %>
+            </td>
+          <% else %>
+            <td><%= link_to driver.full_name, driver %></td>
+          <% end %>
           <td><%= number_to_phone driver.driver_phone,
             pattern: /(\d{3})(\d{3})(\d{4})$/,
             area_code: true %>

--- a/app/views/drivers/_form.html.erb
+++ b/app/views/drivers/_form.html.erb
@@ -137,7 +137,13 @@
   </div>
 
   <div class="actions">
-    <%= f.button :submit, class: "btn btn-primary" %>
+    <% if params[:report] %>
+      <%= hidden_field_tag(:report, params[:report].to_json) %>
+      <%= hidden_field_tag(:search, params[:search].to_json) %>
+      <%= f.button :submit, class: "btn btn-primary" %>
+    <% else %>
+      <%= f.button :submit, class: "btn btn-primary" %>
+    <% end %>
   </div>
 
 <% end %>

--- a/app/views/drivers/reports.html.erb
+++ b/app/views/drivers/reports.html.erb
@@ -15,13 +15,19 @@
         <br>
 
         <%= f.label :current_state, class: 'report-label' %>
+        <% state = params[:q] && params[:q][:current_state_eq] ?
+          params[:q][:current_state_eq] : ''
+        %>
         <%= f.select :current_state_eq,
-          options_for_select(us_states),
+          options_for_select(us_states, state),
           :include_blank => true %>
         <br />
 
         <%= f.label :current_city, class: 'report-label' %>
-        <%= f.text_field :current_city_cont %>
+        <% city = params[:q] && params[:q][:current_city_cont] ?
+          params[:q][:current_city_cont] : ''
+        %>
+        <%= f.text_field :current_city_cont, value: city %>
         <br />
 
         <%= f.label 'Radius (mi)', class: 'report-label' %>

--- a/app/views/drivers/show.html.erb
+++ b/app/views/drivers/show.html.erb
@@ -2,7 +2,6 @@
 
 <div id='driver-show'>
 
-  <p id="notice"><%= notice %></p>
   <h3> <%= @driver.full_name %> </h3>
 
   <p>
@@ -95,9 +94,33 @@
   <% if account_type != 'dispatcher' %>
 
     <td>
-      <%= link_to 'Edit',
-        edit_driver_path(@driver),
-        class: 'btn btn-primary link-btn'%>
+      <% if @report %>
+        <% search_hash = {} %>
+        <% if @search %>
+          <%
+            @search.each do |sp|
+              search_hash[sp] = @search[sp]
+            end
+          %>
+        <% end %>
+        <%= link_to 'Back to Report',
+            drivers_reports_path(
+            q: search_hash,
+            miles: search_hash["miles"]
+          ),
+          class: 'btn btn-primary link-btn' %>
+        <%= link_to 'Edit',
+          edit_driver_path(
+            id: @driver.id,
+            report: @report.map(&:id),
+            search: search_hash
+          ),
+          class: 'btn btn-primary link-btn' %>
+        <% else %>
+          <%= link_to 'Edit',
+            edit_driver_path(@driver),
+            class: 'btn btn-primary link-btn' %>
+      <% end %>
     </td>
 
     <td>
@@ -105,8 +128,17 @@
         @driver,
         method: :delete,
         data: { confirm: 'Are you sure?' },
-        class: 'btn btn-danger link-btn'%>
+        class: 'btn btn-danger link-btn' %>
     </td>
+    <% if @report %>
+      <%= link_to 'Next Driver in Report',
+      driver_path(
+        id: @report[@next_idx],
+        report: @report.map(&:id),
+        search: search_hash
+      ),
+      class: 'btn btn-success link-btn' %>
+    <% end %>
   <% end %>
 
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
   <% end %>
 
   <% flash.each do |name, msg| %>
-    <%= content_tag(:div, msg, class: "alert alert-#{name}") %>
+    <%= content_tag(:div, msg, id: "notice", class: "alert alert-#{name}") %>
   <% end %>
 
 <%= yield %>


### PR DESCRIPTION
When generating a report the report is saved in memory allowing the user
to "tab" through the list and edit each driver in the report. The user can
also hit a button to return to the original report

TG-34